### PR TITLE
Align correctly `count` on Chrome

### DIFF
--- a/src/devtools/panel/style.css
+++ b/src/devtools/panel/style.css
@@ -28,13 +28,14 @@ body {
   background: var(--theme-toolbar-background);
   border-block-end: 1px solid var(--theme-splitter-color);
   display: grid;
-  grid-template-columns: 30px 1fr auto auto;
+  grid-template-columns: 30px 1fr auto auto auto;
   position: relative;
 }
 
 .toolbar input {
   border: none;
   background: transparent;
+  outline: 0; /* Remove blue outline around inputs in Chrome */
 }
 
 .toolbar label, .toolbar input {
@@ -48,16 +49,12 @@ body {
 }
 
 .toolbar .count {
-  position: absolute;
   font-weight: bold;
   color: #666;
-  grid-column: 2 / 3;
-  width: 100%;
-  height: 100%;
-  justify-content: end;
+  grid-column: 3 / 4;
   align-items: center;
   display: flex;
-  right: 0.5em;
+  margin-right: 0.5em;
   pointer-events: none;
 }
 


### PR DESCRIPTION
Fixes #25 ; no overlap anymore on Chrome (and doesn't break FF either).

Chrome:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/8869660/36612532-e11fcd6c-18a4-11e8-97f8-02c33c178d53.png">

FF:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/8869660/36612720-61e4b89a-18a5-11e8-9004-93ae318b8978.png">



Removed absolute positioning, added a css-grid column to circumvent it. 