### PR TITLE
Separate the highlighter layer

### DIFF
--- a/src/content_scripts/content.css
+++ b/src/content_scripts/content.css
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[__devtools_highlighted] {
-  outline: 2px solid #f06;
-  position: relative;
+#__devtools_highlighter {
+  position: absolute; 
+  background-color: #4aa9fab8;
+  display: block; 
+  z-index: 9999;
 }
 
-[__devtools_highlighted]::before {
-  position: absolute;
-  content: "";
-  background: #0006;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+#__devtools_highlighter.hide {
+  display: none;
 }

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -273,7 +273,8 @@ let nextUnique = (function uniqueNumberGenerator() {
  * @param {DOMNode} node The node to be highlighted.
  */
 function highlightNode(node) {
-  const {top, left, width, height} = node.getBoundingClientRect();
+  const {width, height} = node.getBoundingClientRect();
+  const {top, left} = getNodeAbsoluteCoordinates(node);
   const styles = `
     top: ${top}px;
     left: ${left}px;
@@ -284,6 +285,20 @@ function highlightNode(node) {
   highlighterLayer.classList.remove('hide');
   highlighterLayer.setAttribute('style', styles);
 }
+
+/**
+ * Calculates the coordinates of the node relative to the document/window
+ * @param {DOMNode} node, whose coordinates are to be calculated
+ * @returns {Object} containing the top and left coordinates of the node relative to the document
+ */
+function getNodeAbsoluteCoordinates(node) {
+  const {top, left} = node.getBoundingClientRect();
+  return {
+    top: top + window.pageYOffset,
+    left: left + window.pageXOffset
+  }
+}
+
 /**
  * Returns the current highlighter layer
  * Create and add one if doesn't exists

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -37,18 +37,8 @@ port.onMessage.addListener(message => {
     case "clear":
       clear();
       break;
-    case "updateOutlineColor":
-      updateOutlineColor(message.options.color);
-      break;
   }
 });
-
-/**
- * Updates the global `outlineColor` variable with the new color
- */
-function updateOutlineColor(color) {
-  outlineColor = color;
-}
 
 // Helper to send messages back to the background script.
 function sendResponse(message) {
@@ -283,7 +273,7 @@ let nextUnique = (function uniqueNumberGenerator() {
  * @param {DOMNode} node The node to be highlighted.
  */
 function highlightNode(node) {
-  const {top, left, width, height} = node.getBoundingClientRect()
+  const {top, left, width, height} = node.getBoundingClientRect();
   const styles = ` 
     top: ${top}px;
     left: ${left}px;

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -10,12 +10,10 @@ const NODE_LIMIT = 100;
 
 // Special attributes used by the extension. These attributes are added to nodes in the
 // page.
-const STYLING_ATTRIBUTE = "__devtools_highlighted";
 const UNIQUE_ATTRIBUTE = "__devtools_unique";
 
-// Global var to store the outline color
-// used for highlighting elements
-let outlineColor = "#f06";
+// Id of the higlighter layer used to highlight the node
+const HIGHLIGHTER_LAYER_ID = "__devtools_highlighter";
 
 // Open the port to communicate with the background script.
 const browser = window.browser || chrome;
@@ -73,8 +71,9 @@ function clear() {
  * Unhighlight all nodes at once, but keep the list so we can highlight them again later.
  */
 function unhighlightAll() {
-  for (let node of currentNodes) {
-    unhighlightNode(node);
+  let highlighterLayer;
+  if (highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`)) {
+    highlighterLayer.classList.add('hide');
   }
 }
 
@@ -97,7 +96,6 @@ function highlight(index) {
     return;
   }
 
-  unhighlightAll();
   highlightNode(currentNodes[index]);
 }
 
@@ -285,17 +283,25 @@ let nextUnique = (function uniqueNumberGenerator() {
  * @param {DOMNode} node The node to be highlighted.
  */
 function highlightNode(node) {
-  node.setAttribute(STYLING_ATTRIBUTE, true);
-  updateOutline(node);
+  const {top, left, width, height} = node.getBoundingClientRect()
+  const styles = ` 
+    top: ${top}px;
+    left: ${left}px;
+    width: ${width}px;
+    height: ${height}px;`;
+    
+  let highlightLayer;
+  if (!(highlightLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`))) {
+    const body = document.querySelector('body');    
+    highlightLayer = document.createElement('div');
+    highlightLayer.setAttribute('id', HIGHLIGHTER_LAYER_ID);
+    body.appendChild(highlightLayer);
+  } else {
+    highlightLayer.classList.remove('hide');
+  }
+  highlightLayer.setAttribute('style', styles);  
 }
 
-/**
- * Update the outline of the node
- * @param {DOMNode} node  The node whose outline needs to be updated 
- */
-function updateOutline(node) {
-  node.style.outline = `2px solid ${outlineColor}`
-}
 
 /**
  * Tag one node in the page, so we can then select it in the inspector.
@@ -305,22 +311,6 @@ function tagNode(node) {
   node.setAttribute(UNIQUE_ATTRIBUTE, nextUnique());
 }
 
-/**
- * Unhighlight one node in the page.
- * @param {DOMNode} node The node to be unhighlighted.
- */
-function unhighlightNode(node) {
-  node.removeAttribute(STYLING_ATTRIBUTE);
-  resetOutline(node);
-}
-
-/**
- * Removes the outline from the node
- * @param {DOMNode} node  The node whose outline has to be removed 
- */
-function resetOutline(node) {
-  node.style.outline = "none";
-}
 
 /**
  * Untag one node in the page.
@@ -347,7 +337,7 @@ function createNodeResponse(node) {
 
   // Filtering the attributes to remove the special ones the extension is adding.
   attributes = attributes.filter(({ name }) => {
-    return name !== UNIQUE_ATTRIBUTE && name !== STYLING_ATTRIBUTE;
+    return name !== UNIQUE_ATTRIBUTE;
   });
 
   return {

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -61,8 +61,8 @@ function clear() {
  * Unhighlight all nodes at once, but keep the list so we can highlight them again later.
  */
 function unhighlightAll() {
-  let highlighterLayer;
-  if (highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`)) {
+  let highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`);
+  if (highlighterLayer) {
     highlighterLayer.classList.add('hide');
   }
 }
@@ -274,22 +274,31 @@ let nextUnique = (function uniqueNumberGenerator() {
  */
 function highlightNode(node) {
   const {top, left, width, height} = node.getBoundingClientRect();
-  const styles = ` 
+  const styles = `
     top: ${top}px;
     left: ${left}px;
     width: ${width}px;
     height: ${height}px;`;
-    
-  let highlighterLayer;
-  if (!(highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`))) {
-    const body = document.querySelector('body');    
-    highlighterLayer = document.createElement('div');
-    highlighterLayer.setAttribute('id', HIGHLIGHTER_LAYER_ID);
-    body.appendChild(highlighterLayer);
-  } else {
-    highlighterLayer.classList.remove('hide');
-  }
+
+  let highlighterLayer = getHighlighterLayer();
+  highlighterLayer.classList.remove('hide');
   highlighterLayer.setAttribute('style', styles);
+}
+/**
+ * Returns the current highlighter layer
+ * Create and add one if doesn't exists
+ * @returns {DOMNode} node representing the highlighter layer
+ */
+function getHighlighterLayer() {
+  let highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`);
+  if (highlighterLayer) {
+    return highlighterLayer;
+  }
+
+  highlighterLayer = document.createElement('div');
+  highlighterLayer.setAttribute('id', HIGHLIGHTER_LAYER_ID);
+  document.body.appendChild(highlighterLayer);
+  return highlighterLayer;
 }
 
 

--- a/src/content_scripts/content.js
+++ b/src/content_scripts/content.js
@@ -290,16 +290,16 @@ function highlightNode(node) {
     width: ${width}px;
     height: ${height}px;`;
     
-  let highlightLayer;
-  if (!(highlightLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`))) {
+  let highlighterLayer;
+  if (!(highlighterLayer = document.querySelector(`#${HIGHLIGHTER_LAYER_ID}`))) {
     const body = document.querySelector('body');    
-    highlightLayer = document.createElement('div');
-    highlightLayer.setAttribute('id', HIGHLIGHTER_LAYER_ID);
-    body.appendChild(highlightLayer);
+    highlighterLayer = document.createElement('div');
+    highlighterLayer.setAttribute('id', HIGHLIGHTER_LAYER_ID);
+    body.appendChild(highlighterLayer);
   } else {
-    highlightLayer.classList.remove('hide');
+    highlighterLayer.classList.remove('hide');
   }
-  highlightLayer.setAttribute('style', styles);  
+  highlighterLayer.setAttribute('style', styles);
 }
 
 

--- a/src/devtools/panel/devtools-panel.js
+++ b/src/devtools/panel/devtools-panel.js
@@ -25,7 +25,6 @@ const outputEl = document.querySelector(".output");
 const nodeListEl = document.querySelector("#nodes");
 const countEl = document.querySelector(".count");
 const clearButtonEl = document.querySelector(".clear");
-const outlineColorSelectorEl = document.querySelector("#color-selector")
 
 // Start listening for events in the panel, to handle user inputs.
 inputEl.addEventListener("input", find);
@@ -35,21 +34,6 @@ clearButtonEl.addEventListener("click", clear);
 window.addEventListener("click", handleButtonClick);
 window.addEventListener("mouseover", handleNodeOver);
 window.addEventListener("mouseout", handleNodeOut);
-outlineColorSelectorEl.addEventListener("input", updateOutlineColor);
-
-/**
- * Notifies the content script to update the color
- * when the user selects a new color
- */
-function updateOutlineColor() {
-  browser.runtime.sendMessage({
-    tabId: browser.devtools.inspectedWindow.tabId,
-    action: "updateOutlineColor",
-    options: {
-      color: outlineColorSelectorEl.value
-    },
-  });
-}
 
 /**
  * Execute the current query by sending a message to the content script, which will find

--- a/src/devtools/panel/panel.html
+++ b/src/devtools/panel/panel.html
@@ -15,9 +15,6 @@
     </select>
   </label>
   <label><input type="checkbox" id="unlimited"> Unlimited results</label>
-  <label>Outline Color
-    <input id="color-selector" type="color">
-  </label>
 </div>
 <div class="output">
   <div id="message"></div>

--- a/src/devtools/panel/style.css
+++ b/src/devtools/panel/style.css
@@ -28,7 +28,7 @@ body {
   background: var(--theme-toolbar-background);
   border-block-end: 1px solid var(--theme-splitter-color);
   display: grid;
-  grid-template-columns: 30px 1fr auto auto auto auto;
+  grid-template-columns: 30px 1fr auto auto auto;
 }
 
 @supports not (border-block-end:test) {
@@ -68,10 +68,6 @@ body {
   border: 0;
   color: transparent;
   border-inline-end: 1px solid var(--theme-splitter-color);
-}
-
-.toolbar #color-selector {
-  cursor: pointer;
 }
 
 @supports not (border-inline-end:test) {


### PR DESCRIPTION
This is in reference to the issue #3.

Important:
1. The strategy I am using here is to inject a `div` with `position: absolute` at the bottom of the body of the webpage. This will be used as the `highlighterLayer`.
2. I have removed the color picker for the outline since the `highlighterLayer` removes the requirement of showing the outline at all.
3. I have removed the `unhighlightNode` method since we don't have to unhighlight each node separately, hiding the `highlighterLayer` can fulfill the purpose. Thus the method `unhighlightAll` is the only way to unhighlight.
4. Since we are not modifying the node for the purpose of highlighting. I have removed the `STYLING_ATTRIBUTE` and all its references entirely. Instead, I am using a new global constant `HIGHLIGHTER_LAYER_ID` to uniquely identify the layer for the purposes of highlighting and unhighlighting. 